### PR TITLE
Fix typo in example code

### DIFF
--- a/notebooks/DeepSurv Example.ipynb
+++ b/notebooks/DeepSurv Example.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "train_dataset_fp = './example_data.csv'\n",
-    "train_df = pd.read_csv(dataset_fp)\n",
+    "train_df = pd.read_csv(train_dataset_fp)\n",
     "train_df.head()"
    ]
   },


### PR DESCRIPTION
The example code in the Jupyter notebook has a small typo