### PR TITLE
Make test compatible for Python3

### DIFF
--- a/tests/test_deepsurv.py
+++ b/tests/test_deepsurv.py
@@ -62,7 +62,10 @@ class TestDeepSurvTrain():
 
     def test_train(self):
         # Test if network has undefined parameters
-        assert self.log.has_key('best_params') == True
+        if sys.version_info.major == 2
+            assert self.log.has_key('best_params') == True
+        else:
+            assert 'best_params' in self.log.keys()
         params_is_nan = [is_nan for params in self.log['best_params'] for is_nan in numpy.isnan(params.flatten())]
         assert numpy.any(params_is_nan) == False
 

--- a/tests/test_deepsurv.py
+++ b/tests/test_deepsurv.py
@@ -1,4 +1,5 @@
 
+import sys
 import pytest
 
 import deepsurv


### PR DESCRIPTION
python3 dictionary doesnt have `haskey` attribute